### PR TITLE
Added JSON Config Files

### DIFF
--- a/MergeFRCPipeline.py
+++ b/MergeFRCPipeline.py
@@ -187,7 +187,13 @@ configFile = "/boot/frc.json"
 
 pipelineConfig = "pipelineConfig.json"
 
-MergeVisionPipeLineTableName = "MergeVisionPipeline"
+with open(pipelineConfig) as json_file:
+    data = json.load(json_file)
+
+MergeVisionPipeLineTableName = data["networkTableName"]
+TapeEnabled = data["Tape"]
+PowerCellEnabled = data["PowerCell"]
+
 #MergeVisionPublishingTable = "MergeVision"
 
 class CameraConfig: pass
@@ -354,8 +360,8 @@ if __name__ == "__main__":
 
     #PipeLine Table Values, Unique for Each PipeLine
     networkTableVisionPipeline.putBoolean("Driver", False)
-    networkTableVisionPipeline.putBoolean("Tape", True)
-    networkTableVisionPipeline.putBoolean("PowerCell", False)
+    networkTableVisionPipeline.putBoolean("Tape", TapeEnabled)
+    networkTableVisionPipeline.putBoolean("PowerCell", PowerCellEnabled)
     #networkTable.putBoolean("ControlPanel", False)
     networkTableVisionPipeline.putBoolean("WriteImages", False)
     networkTableVisionPipeline.putBoolean("SendMask", False)

--- a/buildScript.py
+++ b/buildScript.py
@@ -1,6 +1,7 @@
 import zipfile
 
-FILENAME = "visionComp.zip"
+FILENAME = "visionCompPi20.zip"
+FILENAME2 = "visionCompPi21.zip"
 
 #create a ZipFile object
 zipObj = zipfile.ZipFile(FILENAME, 'w')
@@ -16,5 +17,21 @@ zipObj.write('VisionUtilities.py')
 zipObj.write('NetworkTablePublisher.py')
 zipObj.write('MergeFRCPipeline.py','uploaded.py')
 zipObj.write('CornersVisual4.py')
+zipObj.write('pipelineConfigPi20.json', 'pipelineConfig.json')
 
-print("I should have wrote the file: " + FILENAME)
+
+zipObj2 = zipfile.ZipFile(FILENAME2, 'w')
+
+zipObj2.write('ControlPanel.py')
+zipObj2.write('DistanceFunctions.py')
+zipObj2.write('FindBall.py')
+zipObj2.write('FindTarget.py')
+zipObj2.write('VisionConstants.py')
+zipObj2.write('VisionMasking.py')
+zipObj2.write('VisionUtilities.py')
+zipObj2.write('NetworkTablePublisher.py')
+zipObj2.write('MergeFRCPipeline.py','uploaded.py')
+zipObj2.write('CornersVisual4.py')
+zipObj2.write('pipelineConfigPi21.json', 'pipelineConfig.json')
+
+print("I have wrote the file: " + FILENAME + " and " + FILENAME2)

--- a/pipelineConfigPi20.json
+++ b/pipelineConfigPi20.json
@@ -1,0 +1,5 @@
+{
+    "networkTableName": "MergeVisionPiplinePi20",
+    "Tape": false,
+    "PowerCell": true
+}

--- a/pipelineConfigPi21.json
+++ b/pipelineConfigPi21.json
@@ -1,0 +1,5 @@
+{
+    "networkTableName": "MergeVisionPiplinePi21",
+    "Tape": true,
+    "PowerCell": false
+}


### PR DESCRIPTION
I added 2 JSON files (pipelineConfigPi20 and pipelineConfigPi21). These files hold important config info for each separate competition Pi. 

buildScript.py now creates 2 files (visionCompPi20 and visionCompPi21), which are identical except with these 2 JSON files. When deploying, make sure to upload the right one to your specific pi!