### PR TITLE
Add cx based yaw to ball finding for autonomous

### DIFF
--- a/MergeViewer.py
+++ b/MergeViewer.py
@@ -91,8 +91,9 @@ else:  # implies images are to be read
     #images, imagename = load_images_from_folder("./PowerCellFullMystery")
     #images, imagename = load_images_from_folder("./PowerCellSketchup")
     #images, imagename = load_images_from_folder("./LifeCamPhotos")
+
     # This is the one with the power cell
-    #images, imagename = load_images_from_folder("./PowerCellFullRobot")
+    images, imagename = load_images_from_folder("./PowerCellFullRobot")
 
     # Outer Target Images
     #images, imagename = load_images_from_folder("./OuterTargetProblems")
@@ -101,7 +102,7 @@ else:  # implies images are to be read
     #images, imagename = load_images_from_folder("./OuterTargetFullScale")
     #images, imagename = load_images_from_folder("./OuterTargetRingTest")
     #images, imagename = load_images_from_folder("./OuterTargetHalfDistance")
-    images, imagename = load_images_from_folder("./OuterTargetFullDistance")
+    #images, imagename = load_images_from_folder("./OuterTargetFullDistance")
     #images, imagename = load_images_from_folder("./OuterTargetSketchup")
     #images, imagename = load_images_from_folder("./OuterTargetLiger")
 
@@ -119,8 +120,8 @@ server = False
 cameraConfigs = []
 
 Driver = False
-Tape = True
-PowerCell = False
+Tape = False
+PowerCell = True
 ControlPanel = False
 
 # Method 1 is based on measuring distance between leftmost and rightmost


### PR DESCRIPTION
Gabby and Justin were working on autonomous last night and these extra yaw calculations are for specific autonomous moments in the trench.  Done as additions, only two changes to what was there.  There is an additional request to set nothing found on ball yaws (now 3 of them) to -99, and perhaps Justin wants no distance set to -99 rather than -1.  He said he would post on slack.